### PR TITLE
Prevent htmlize from trashing match data

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -176,7 +176,7 @@
     (with-temp-buffer
       (insert id " ")
       (if htmlize
-          (let ((pretty-buffer (htmlize-buffer buffer)))
+          (let ((pretty-buffer (save-match-data (htmlize-buffer buffer))))
             (insert-buffer-substring pretty-buffer)
             (kill-buffer pretty-buffer))
         (insert-buffer-substring buffer))


### PR DESCRIPTION
`htmlize-buffer` modifies the global regex match data. Because it's being run in a hook for impatient-mode it's trashing the match data when other functions -- `dabbrev` in particular -- aren't expecting it. This patch restores the match data after htmlize has run, leaving the Emacs global state clean.
