### PR TITLE
Fix live-buffer update issue.

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -153,7 +153,8 @@
                            (imp--buffer-list))))
         (add-to-list 'imp-related-files full-file-name)
         (if live-buffer
-            (with-current-buffer (first live-buffer)
+            (with-temp-buffer
+              (insert-buffer (first live-buffer))
               (if (imp--should-not-cache-p path)
                   (httpd-send-header proc "text/plain" 200
                                      :Cache-Control "no-cache")


### PR DESCRIPTION
Awhile back httpd-send-header was changed so that the same buffer cannot
be sent twice, as a precaution against mistakes. simple-httpd should
probably log a warning in situations like this.

This addresses #9.
