### PR TITLE
Add a Cask build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.elc
+*.tar
+*-pkg.el
+.cask

--- a/Cask
+++ b/Cask
@@ -1,0 +1,2 @@
+(source melpa)
+(package-file "impatient-mode.el")

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+EMACS   ?= emacs
+CASK    ?= cask
+VIRTUAL := $(CASK) exec $(EMACS)
+BATCH   := $(VIRTUAL) -batch -Q -L .
+
+PACKAGE := impatient-mode
+VERSION := $(shell $(CASK) version)
+
+EL = impatient-mode.el
+ELC = $(EL:.el=.elc)
+EXTRA_DIST = README.md loading.html jquery.js index.html
+
+.PHONY : all compile package clean
+
+all : compile package
+
+.cask : Cask
+	cask install
+	touch .cask
+
+compile: .cask $(ELC)
+
+package : $(PACKAGE)-$(VERSION).tar
+
+$(PACKAGE)-pkg.el : Cask
+	$(CASK) package
+
+$(PACKAGE)-$(VERSION).tar : $(EL) $(PACKAGE)-pkg.el $(EXTRA_DIST)
+	tar -cf $@ --transform "s,^,$(PACKAGE)-$(VERSION)/," $^
+
+clean:
+	$(RM) *.tar *.elc $(PACKAGE)-pkg.el
+
+%.elc: %.el
+	$(BATCH) -f batch-byte-compile $<


### PR DESCRIPTION
This provides a [Cask](https://github.com/cask/cask) build; useful since impatient-mode.el has dependencies. Once Cask is installed just "`make`" and impatient-mode.el will be compiled, showing any compiler warnings.

This isn't essential. Its purpose is to make it easy to have the compiler to check up on the code and provide proper package builds for non-MELPA distribution.
