### PR TITLE
Use UTF-8 in buffer listing (fixes #21)

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -146,7 +146,7 @@ buffer."
 
 (defun imp-serve-buffer-list (proc)
   "Serve a list of published buffers."
-  (with-httpd-buffer proc "text/html"
+  (with-httpd-buffer proc "text/html; charset=utf-8"
     (insert "<html><head>\n")
     (insert "<title>impatient-mode buffer list</title>\n")
     (insert "</head><body>\n")


### PR DESCRIPTION
It still works fine without it, but it's ugly.
