### PR TITLE
Fix problems with URLs including special characters

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -119,8 +119,9 @@ buffer."
   "Visit the buffer in a browser."
   (interactive)
   (impatient-mode)
-  (browse-url (format "http://%s:%d/imp/live/%s"
-                      system-name httpd-port (buffer-name))))
+  (browse-url
+   (format "http://%s:%d/imp/live/%s/"
+           (system-name) httpd-port (url-hexify-string (buffer-name)))))
 
 (defun imp-buffer-enabled-p (buffer)
   "Return t if buffer has impatient-mode enabled."

--- a/index.html
+++ b/index.html
@@ -96,8 +96,8 @@
           // now we need to tweak the stylesheet links so that firefox will refresh them properly
           $('link', frameToDocument(iframeJQ[0])).each(function(index, el) {
             var href = $(el).attr('href');
-            // don't refresh the random data:text stylesheets that chrome inserts
-            if(href && href.indexOf('data:text') != 0) {
+            // Only refresh impatient-mode hosted content
+            if(href && !/^[a-zA-z]+:\/\//.exec(href)) {
               $(el).attr('href', $(el).attr('href') + '?' + new Date().getTime());
             }
           });


### PR DESCRIPTION
This fixes two separate problems where a URL contains a question mark. One covers the case when the buffer name has special characters and the second avoids mangling absolute URLs (external resources not under the influence of impatient-mode).
