### PR TITLE
Modify imp-related-files from the context of the buffer

### DIFF
--- a/impatient-mode.el
+++ b/impatient-mode.el
@@ -185,7 +185,8 @@ buffer."
              (live-buffer (cl-remove-if-not
                            (lambda (buf) (equal full-file-name (buffer-file-name buf)))
                            (imp--buffer-list))))
-        (add-to-list 'imp-related-files full-file-name)
+        (with-current-buffer buffer-name
+          (add-to-list 'imp-related-files full-file-name))
         (if live-buffer
             (with-temp-buffer
               (insert-buffer-substring (cl-first live-buffer))


### PR DESCRIPTION
Modifying it from the global context didn't change the buffer-local value.

It prevented the resources such as the CSS files from triggering a refresh.